### PR TITLE
Fix typo.

### DIFF
--- a/lessons/httpmethods.html
+++ b/lessons/httpmethods.html
@@ -109,7 +109,7 @@
 							</ul>
 						</div>
 						<div class="tab-pane fade" id="put">
-							<p>PUT is most-often utilized for update capabilities, PUT-ing to a known resource URI with the request request body containing the newly-updated representation of the original resource.</p>
+							<p>PUT is most-often utilized for update capabilities, PUT-ing to a known resource URI with the request body containing the newly-updated representation of the original resource.</p>
 							<p>However, PUT can also be used to create a resource in the case where the resource ID is chosen by the client instead of by the server.  In other words, if the PUT is to a URI that contains the value of a non-existent resource ID.  Again, the request body contains a resource representation.  Many feel this is convoluted and confusing.  Consequently, this method of creation should be used sparingly, if at all.</p>
 							<p>Alternatively, use POST to create new resources and provide the client-defined ID in the body representation—presumably to a URI that doesn't include the ID of the resource (see POST below).</p>
 							<p>On successful update, return 200 (or 204 if not returning any content in the body) from a PUT.  If using PUT for create, return HTTP status 201 on successful creation.  A body in the response is optional—providing one consumes more bandwidth.   It is not necessary to return a link via a Location header in the creation case since the client already set the resource ID.</p>


### PR DESCRIPTION
The 'request' word was written twice in the PUT verb description.
