### PR TITLE
Removing safety section from idempotency topic.  Was duplicate text.

### DIFF
--- a/lessons/idempotency.html
+++ b/lessons/idempotency.html
@@ -66,22 +66,11 @@
 				</div>
 				<div class="span12">
 					<p>Idempotence is a funky word that often hooks people. Idempotence is sometimes a confusing concept, at least from the academic definition.</p>
-					<p>From a RESTful service standpoint, for an operation (or service call) to be idempotent, clients can make that same call repeatedly while producing the same result—operating much like a “setter” method in a programming language. In other words, making multiple identical requests has the same effect as making a single request. Note that while idempotent operations produce the same result on the server (side effects), the response itself may not be the same (e.g. a resource's state may change between requests).</p>
+					<p>From a RESTful service standpoint, for an operation (or service call) to be idempotent, clients can make that same call repeatedly while producing the same result. In other words, making multiple identical requests has the same effect as making a single request. Note that while idempotent operations produce the same result on the server (no side effects), the response itself may not be the same (e.g. a resource's state may change between requests).</p>
 					<p>The PUT and DELETE methods are defined to be idempotent. However, there is a caveat on DELETE. The problem with DELETE, which if successful would normally return a 200 (OK) or 204 (No Content), will often return a 404 (Not Found) on subsequent calls, unless the service is configured to "mark" resources for deletion without actually deleting them. However, when the service actually deletes the resource, the next call will not find the resource to delete it and return a 404. However, the state on the server is the same after each DELETE call, but the response is different.</p>
-					<p>GET, HEAD, OPTIONS and TRACE methods are defined as safe, which makes them idempotent also. Read the section on safety below.</p>
+					<p>GET, HEAD, OPTIONS and TRACE methods are defined as safe, meaning they are only intended for retrieving data.  This makes them idempotent as well since multiple, identical requests will behave the same.</p>
 				</div>
-			</div>
-			<div class="row">
-				<div class="span12">
-					<h2>Safetey</h2>
-				</div>
-				<div class="span12">
-					<p>Idempotence is a funky word that often hooks people. Idempotence is sometimes a confusing concept, at least from the academic definition.</p>
-					<p>From a RESTful service standpoint, for an operation (or service call) to be idempotent, clients can make that same call repeatedly while producing the same result—operating much like a “setter” method in a programming language. In other words, making multiple identical requests has the same effect as making a single request. Note that while idempotent operations produce the same result on the server (side effects), the response itself may not be the same (e.g. a resource's state may change between requests).</p>
-					<p>The PUT and DELETE methods are defined to be idempotent. However, there is a caveat on DELETE. The problem with DELETE, which if successful would normally return a 200 (OK) or 204 (No Content), will often return a 404 (Not Found) on subsequent calls, unless the service is configured to "mark" resources for deletion without actually deleting them. However, when the service actually deletes the resource, the next call will not find the resource to delete it and return a 404. However, the state on the server is the same after each DELETE call, but the response is different.</p>
-					<p>GET, HEAD, OPTIONS and TRACE methods are defined as safe, which makes them idempotent also. Read the section on safety below.</p>
-				</div>
-			</div>
+			</div>			
 			<hr>
 			<footer>
 				<p>


### PR DESCRIPTION
On the idempotency lesson, there were two sections, Idempotence and Safety.  The Safety section was just the Idempotence one duplicated.  I removed the Safety section and updated the Idempotence section to be more clear.  

One other thing I did was to remove the reference to "setter" methods in programming languages.  I think that will just confuse people.
![tmp](https://f.cloud.github.com/assets/5596986/1471376/0d231e10-45e0-11e3-94d9-9f87144b4d0c.png)
