### PR TITLE
Adding "formats"

### DIFF
--- a/lessons/restquicktips.html
+++ b/lessons/restquicktips.html
@@ -111,7 +111,7 @@
                         </dl>
                     </p>
 					<h2>Offer Both JSON and XML</h2>
-					<p>Favor JSON support unless you're in a highly-standardized and regulated industry that requires XML, Schema validation and namespaces. And offer both JSON and XML unless the costs are staggering. Ideally, let consumers switch between using the HTTP Accept header, or by just changing an extension from .xml to .json on the URL.</p>
+					<p>Favor JSON support unless you're in a highly-standardized and regulated industry that requires XML, Schema validation and namespaces. And offer both JSON and XML unless the costs are staggering. Ideally, let consumers switch between formats using the HTTP Accept header, or by just changing an extension from .xml to .json on the URL.</p>
 					<p>Be warned though, as soon as we start talking about XML support, we start talking about schemas for validation, namespaces, etc. Unless required by your industry, avoid supporting all that complexity initially, if ever. JSON is designed to be simple, terse and functional. Create your XML to look like that if you can.</p>
                     <p>In other words, make the XML that is returned more JSON-like: simple and easy to read, without the schema and namespace details present&mdash;just data and links.  If it ends up being more complex than this, the cost of XML will be staggering. In my experience nobody uses the XML responses anyway over the last several years.  It's just too expensive to consume.</p>
                     <p>Note that <a href="http://json-schema.org/">JSON-Schema</a> offers schema-style validation capabilities, if you need that sort of thing.</p>


### PR DESCRIPTION
I think adding "formats" after "between" makes it clearer what the switching will be between. Although there is enough context to understand it implicitly, I prefer the explicit version. I think it also makes the sentence slightly easier to read.