### PR TITLE
Added/changed to 405 for resources that can not be deleted at all

### DIFF
--- a/lessons/httpmethods.html
+++ b/lessons/httpmethods.html
@@ -104,8 +104,8 @@
 							<tr>
 								<td>DELETE</td>
 								<td>Delete</td>
-								<td>405 (Not Allowed), unless you want to delete the whole collection—not often desirable.</td>
-								<td>200 (OK).  404 (Not Found) if ID not found. 405 (Not allowed) if deletion on this resource is not allowed at all for any user.</td>
+								<td>405 (Method Not Allowed), unless you want to delete the whole collection—not often desirable.</td>
+								<td>200 (OK).  404 (Not Found) if ID not found. 405 (Method Not allowed) if deletion on this resource is not allowed at all for any user.</td>
 							</tr>
 						</tbody>
 					</table>

--- a/lessons/httpmethods.html
+++ b/lessons/httpmethods.html
@@ -104,8 +104,8 @@
 							<tr>
 								<td>DELETE</td>
 								<td>Delete</td>
-								<td>404 (Not Found), unless you want to delete the whole collection—not often desirable.</td>
-								<td>200 (OK).  404 (Not Found), if ID not found or invalid.</td>
+								<td>405 (Not Allowed), unless you want to delete the whole collection—not often desirable.</td>
+								<td>200 (OK).  404 (Not Found) if ID not found. 405 (Not allowed) if deletion on this resource is not allowed at all for any user.</td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
If a resource (a collection or a singular resource) does not supprt the method **at all** it should return the 405 (Not Allowed) status code.

A 404 indicates that the resource does not exist. The resource (noun) clearly exist.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

> 10.4.5 404 Not Found
> The server has not found anything matching the Request-URI

**For a collection:**
The server have found the resource (/customers), so 404 does not apply here.

**For a singular resource:**
The server have found the resource (/customers/existing-id), so 404 does not apply here.

---

> 10.4.6 405 Method Not Allowed
> The method specified in the Request-Line is not allowed for the resource identified by the Request-URI. The response MUST include an Allow header containing a list of valid methods for the requested resource.

**For a collection:**
This applies if you don't want to offer to delete the resource (/customers) to **anyone**. (at least thorugh this api of course)

**For a singular resource:**
The server have found the resource (/customers/existing-id), but this singular resource can not be deleted by **anyone**.  (at least thorugh this api of course)

If just the specific caller is not allowed to delete it, that's another issue (401/403). 

That's how I read the spec anyway.
